### PR TITLE
Toolbox YouTrack is now TBX

### DIFF
--- a/data.json
+++ b/data.json
@@ -360,7 +360,7 @@
         "github": "",
         "product_page": "https://www.jetbrains.com/toolbox/app/",
         "description": "A control panel for your tools and projects",
-        "issue_tracker": "ALL",
+        "issue_tracker": "TBX",
         "aliases": []
     },
     {


### PR DESCRIPTION
Resolves https://github.com/JetBrains-Community/discord/issues/6 by changing toolbox YouTrack acronym from `ALL` to `TBX`.